### PR TITLE
Fix CI: bump bc-detect-secrets to 1.5.47, add platformdirs

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -30,10 +30,11 @@ requirements:
     - setuptools
   run:
     - urllib3 >=1.26.20
+    - platformdirs
     - typing_extensions <5.0.0,>=4.5.0
     - python
     - bc-python-hcl2 ==0.4.3
-    - bc-detect-secrets ==1.5.45
+    - bc-detect-secrets ==1.5.47
     - bc-jsonpath-ng ==1.6.1
     - pycep-parser ==0.5.1
     - tabulate >=0.9.0,<0.10.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: checkov
-  version: "3.2.489"
+  version: "3.2.526"
 
 package:
   name: ${{ name|lower }}
@@ -10,19 +10,19 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/${{ name[0] }}/${{ name }}/checkov-${{ version }}.tar.gz
-  sha256: ca3d92c8b1c14405f00cdb9f2cea726f209b1967fcca2e9386800d33233da274
+  sha256: 834d60811898675035187214412290013ba977a9d0b884f3e07545b654742bad
 
 build:
   skip: (match(python, "<3.11") and osx and x86_64)
   script: ${{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 0
 
 requirements:
   build:
     - if: build_platform != target_platform
-      then: python
-    - if: build_platform != target_platform
-      then: cross-python_${{ target_platform }}
+      then:
+        - python
+        - cross-python_${{ target_platform }}
   host:
     - python
     - pyyaml
@@ -68,9 +68,9 @@ requirements:
     - prettytable <4.0.0,>=3.6.0
     - charset-normalizer <4.0.0,>=3.1.0
     - if: match(python, "<3.11") and unix and x86_64
-      then: pyston_lite_autoload ==2.3.5
-    - if: match(python, "<3.11") and unix and x86_64
-      then: pyston_lite ==2.3.5
+      then:
+        - pyston_lite_autoload ==2.3.5
+        - pyston_lite ==2.3.5
     - requests <3.0.0,>=2.28.0
     - yarl <2.0.0,>=1.9.1
     - spdx-tools >=0.8.0,<0.9.0


### PR DESCRIPTION
Branched off autotick-bot PR #250 (`3.2.526_h57d3fd`).

## Problem
CI fails on all linux/win/osx_64 builds (osx_arm64 happens to skip due to a different installed version) at `pip check`:
- `checkov 3.2.526 requires platformdirs, which is not installed.`
- `checkov 3.2.526 has requirement bc-detect-secrets==1.5.47, but you have bc-detect-secrets 1.5.45.`

## Fix
- Bump pin: `bc-detect-secrets ==1.5.45` → `==1.5.47`
- Add `platformdirs` to run dependencies

Supersedes / fixes up #250.